### PR TITLE
Prerelease will now discard local changes

### DIFF
--- a/sequenzia
+++ b/sequenzia
@@ -142,16 +142,16 @@ then
       docker compose restart web;;
 		prerelease)
 		  echo "Updating to latest prerelease commit..."
-		  docker exec -it "$(docker compose ps web | tail -n +2 | awk '{ print $1 }')" sh -c "cd /across/sequenzia-web/ && git fetch && git checkout prerelease" &&
+		  docker exec -it "$(docker compose ps web | tail -n +2 | awk '{ print $1 }')" sh -c "cd /across/sequenzia-web/ && git fetch && git reset --hard origin/prerelease" &&
 		  if [ "$(git rev-parse --abbrev-ref HEAD)" = "prerelease" ]; then
         docker exec -it "$(docker compose ps watchdog | tail -n +2 | awk '{ print $1 }')" sh -c '/wait && mysql -h "$DATABASE_HOST" -u "$DATABASE_USERNAME" -p"$DATABASE_PASSWORD" kanmi_system < /across/compliance_v20.sql' &&
-        docker exec -it "$(docker compose ps authware | tail -n +2 | awk '{ print $1 }')" sh -c "cd /across/sequenzia-framework/ && git fetch && git checkout prerelease" &&
+        docker exec -it "$(docker compose ps authware | tail -n +2 | awk '{ print $1 }')" sh -c "cd /across/sequenzia-framework/ && git fetch && git reset --hard origin/prerelease" &&
         docker compose restart authware &&
-        docker exec -it "$(docker compose ps framework | tail -n +2 | awk '{ print $1 }')" sh -c "cd /across/sequenzia-framework/ && git fetch && git checkout prerelease" &&
+        docker exec -it "$(docker compose ps framework | tail -n +2 | awk '{ print $1 }')" sh -c "cd /across/sequenzia-framework/ && git fetch && git reset --hard origin/prerelease" &&
         docker compose restart framework &&
-        docker exec -it "$(docker compose ps fileworker | tail -n +2 | awk '{ print $1 }')" sh -c "cd /across/sequenzia-framework/ && git fetch && git checkout prerelease" &&
+        docker exec -it "$(docker compose ps fileworker | tail -n +2 | awk '{ print $1 }')" sh -c "cd /across/sequenzia-framework/ && git fetch && git reset --hard origin/prerelease" &&
         docker compose restart fileworker &&
-        docker exec -it "$(docker compose ps web | tail -n +2 | awk '{ print $1 }')" sh -c "cd /across/sequenzia-web/ && git fetch && git checkout prerelease" &&
+        docker exec -it "$(docker compose ps web | tail -n +2 | awk '{ print $1 }')" sh -c "cd /across/sequenzia-web/ && git fetch && git reset --hard origin/prerelease" &&
         docker compose restart web
       else
         echo "Please run 'git checkout prerelease' to update the compose scripts. This is to ensure that the latest compliance file is used (if needed)."


### PR DESCRIPTION
Previously the command would fail sometimes because of package-lock.json being modified. This will discard it all and grab directly from origin/prerelease